### PR TITLE
standard_to_text2: outputs one file per passage file

### DIFF
--- a/scripts/site_to_standard.py
+++ b/scripts/site_to_standard.py
@@ -23,6 +23,7 @@ or using filenames of a site-formatted XML file.
 def site2passage(filename):
     """Opens a file and returns its parsed Passage object"""
     with open(filename, encoding="utf-8") as f:
+        print("Opening: "+filename)
         return ucca.convert.from_site(ElementTree().parse(f))
 
 

--- a/scripts/standard_to_text2.py
+++ b/scripts/standard_to_text2.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import sys
+
+from ucca.convert import to_text
+
+import argparse
+import os
+from tqdm import tqdm
+
+from ucca.ioutil import file2passage, passage2file
+
+desc = """Parses an XML in UCCA standard format, and writes their tokens into a text file."""
+
+
+def main(args):
+    os.makedirs(args.outdir, exist_ok=True)
+    for filename in tqdm(args.filenames, desc="Converting", unit=" passages"):
+        passage = file2passage(filename)
+        basename = os.path.splitext(os.path.basename(filename))[0]
+        outfile = open(args.outdir + os.path.sep + basename + ".txt","w",encoding="utf-8")
+
+        for line in to_text(passage, lang=args.lang):
+            print(line, file=outfile)
+
+
+if __name__ == '__main__':
+    argparser = argparse.ArgumentParser(description=desc)
+    argparser.add_argument('filenames', nargs='+', help="XML file names to convert")
+    argparser.add_argument('-o', '--outdir', default='.', help="output directory")
+    argparser.add_argument('-v', '--verbose', action="store_true", help="verbose output")
+    argparser.add_argument("-l", "--lang", default="en", help="language two-letter code for sentence model")
+
+    main(argparser.parse_args())

--- a/ucca/convert.py
+++ b/ucca/convert.py
@@ -251,8 +251,10 @@ def _parse_site_units(elem, parent, passage, groups, elem2node):
     # Unit tag means its a regular, hierarchically built unit
     if elem.tag == SiteCfg.Tags.Unit:
         node = _get_node(elem)
+
         # Only nodes created by now are the terminals, or discontiguous units
         if node is not None:
+
             if node.tag == layer0.NodeTags.Word:
                 parent.add(EdgeTags.Terminal, node)
             elif node.tag == layer0.NodeTags.Punct:
@@ -262,6 +264,10 @@ def _parse_site_units(elem, parent, passage, groups, elem2node):
                 # discontiguous unit, whose node was already created.
                 # So, we don't need to create the node, just keep processing
                 # our subelements (as subelements of the discontiguous unit)
+
+                # Added by Omri to address cases where remote units direct at the chunks of discontiguous units
+                SiteUtil.set_node(elem, node, elem2node)
+
                 for subelem in elem:
                     tbd += _parse_site_units(subelem, node, passage,
                                              groups, elem2node)
@@ -274,6 +280,10 @@ def _parse_site_units(elem, parent, passage, groups, elem2node):
                 SiteCfg.Attr.ElemTag)]
             node = l1.add_fnode(parent, edge_tag)
             SiteUtil.set_node(work_elem, node, elem2node)
+
+            # Added by Omri to address cases where remote units direct at the chunks of discontiguous units
+            SiteUtil.set_node(elem, node, elem2node)
+
             _fill_attributes(work_elem, node)
             # For iterating the subelements, we don't use work_elem, as it may
             # out of the current XML hierarchy we are processing (discont...)


### PR DESCRIPTION
convert.py: support for discontiguous remotes where the remote references one of the discontiguous unit's parts and not the whole.